### PR TITLE
Client settings: Make it possible to define a server address for each client interface

### DIFF
--- a/crates/client/src/main.rs
+++ b/crates/client/src/main.rs
@@ -83,7 +83,6 @@ fn main() {
         // TODO: Can we handle this in a more generic way?
         let client_socket_address = settings.interfaces.first().unwrap().bind_address; //"172.16.200.2:0".parse().unwrap();
 
-        let server_socket_address = settings.server_address; //"172.16.200.4:40000".parse().unwrap();
         let server_endpoint_id = settings.server_id;
 
         let client_id = settings.peer_id;
@@ -118,14 +117,14 @@ fn main() {
             connection_info.push(ConnectionInfo {
                 interface_name: interface_config.interface_name.clone(),
                 local_address: interface_config.bind_address,
-                destination_address: server_socket_address,
+                destination_address: interface_config.server_address,
                 destination_endpoint_id: server_endpoint_id
             });
 
             connection_manager.create_new_connection(
                 interface_config.interface_name.clone(),
                 interface_config.bind_address,
-                server_socket_address,
+                interface_config.server_address,
                 server_endpoint_id
             ).await.unwrap()
         }
@@ -230,7 +229,7 @@ fn main() {
                     match connection_manager.create_new_connection(
                         interface_config.interface_name.clone(),
                         interface_config.bind_address,
-                        server_socket_address,
+                        interface_config.server_address,
                         server_endpoint_id
                     ).await {
                         Ok(()) => { debug!("Restarted connection on: {}", interface_config.interface_name) }

--- a/crates/common/src/settings.rs
+++ b/crates/common/src/settings.rs
@@ -23,6 +23,7 @@ pub struct ServerSettings {
 pub struct Interface {
     pub interface_name: String,
     pub bind_address: SocketAddr,
+    pub server_address: SocketAddr,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -46,7 +47,6 @@ pub struct ClientSettings {
     pub peer_id: u16,
     pub interfaces: Vec<Interface>,
     pub server_id: u16,
-    pub server_address: SocketAddr,
     pub tunnel_config: TunnelSettings,
     pub static_routes: Vec<RouteConfig>,
     pub connection_timeout: u64,

--- a/examples/many-to-one/client.json
+++ b/examples/many-to-one/client.json
@@ -3,15 +3,16 @@
   "interfaces": [
     {
       "interface_name": "veth1",
-      "bind_address": "172.16.200.2:0"
+      "bind_address": "172.16.200.2:0",
+      "server_address": "172.16.200.4:40000"
     },
     {
       "interface_name": "veth2",
-      "bind_address": "172.16.200.3:0"
+      "bind_address": "172.16.200.3:0",
+      "server_address": "172.16.200.4:40000"
     }
   ],
   "server_id": 1,
-  "server_address": "172.16.200.4:40000",
   "tunnel_config": {
     "tunnel_device_address": "10.12.0.5",
     "netmask": "255.255.255.0",


### PR DESCRIPTION
This makes it possible for the server to have multiple network interfaces as well.